### PR TITLE
Add .h2 to the supported extensions

### DIFF
--- a/cpp2/package.json
+++ b/cpp2/package.json
@@ -20,7 +20,8 @@
             {
                 "id": "cpp2",
                 "extensions": [
-                    ".cpp2"
+                    ".cpp2",
+                    ".h2"
                 ],
                 "configuration": "./language-configuration.json"
             }


### PR DESCRIPTION
Maybe `.hpp2` files should be added instead, or both? Came across this need when I added headers to a project. Currently the C++2 docs do not specify anything about headers, but it is a nice to have.

Thank you for making this amazing extension by the way, it is a life-saver!