### PR TITLE
Add support for function template

### DIFF
--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -470,7 +470,7 @@ repository:
     begin: |
       (?x)
       ({{identifier}})
-      (?=\s*[:]\s*[\(])
+      (?=\s*[:]\s*[\(|<])
     beginCaptures:
       "1": { name: entity.name.function.declaration.cpp2 }
     end: (?<=[\};])

--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -862,7 +862,7 @@ repository:
 
   function-typing:
     name: meta.typing.cpp2
-    begin: (:)(?=[\s\(])
+    begin: (:)(?=[\s*[\(<]])
     beginCaptures:
       "1": { name: punctuation.separator.colon.cpp2 }
     end: (?=\s*(?=[=;]))
@@ -944,9 +944,10 @@ repository:
     name: meta.function-type.cpp2
     begin: |
       (?x)
-      (?=\()
+      (?=[\(<])
     end: (?=[=;])
     patterns:
+    - include: '#template'
     - include: '#parenthesized-parameters'
     - include: '#function-trailing-return'
   

--- a/cpp2/syntaxes/cpp2.tmLanguage
+++ b/cpp2/syntaxes/cpp2.tmLanguage
@@ -2326,7 +2326,7 @@
         <key>name</key>
         <string>meta.typing.cpp2</string>
         <key>begin</key>
-        <string>(:)(?=[\s\(])</string>
+        <string>(:)(?=[\s*[\(&lt;]])</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -2539,12 +2539,16 @@
         <string>meta.function-type.cpp2</string>
         <key>begin</key>
         <string>(?x)
-(?=\()
+(?=[\(&lt;])
 </string>
         <key>end</key>
         <string>(?=[=;])</string>
         <key>patterns</key>
         <array>
+          <dict>
+            <key>include</key>
+            <string>#template</string>
+          </dict>
           <dict>
             <key>include</key>
             <string>#parenthesized-parameters</string>

--- a/cpp2/syntaxes/cpp2.tmLanguage
+++ b/cpp2/syntaxes/cpp2.tmLanguage
@@ -1306,7 +1306,7 @@
         <key>begin</key>
         <string>(?x)
 ([_[:alpha:]][_[:alnum:]]*)
-(?=\s*[:]\s*[\(])
+(?=\s*[:]\s*[\(|&lt;])
 </string>
         <key>beginCaptures</key>
         <dict>


### PR DESCRIPTION
Here's a first pull request with one tiny change, just to get the hang of it.
I've added support for function template.
_Before:_
![image](https://github.com/user-attachments/assets/ad6a542d-5aee-49ec-aac4-461993f39b53)
_After:_
![image](https://github.com/user-attachments/assets/05c98a31-2ee6-4cd5-851a-599b632bd864)

Here is the cppfront documentation about it:
https://hsutter.github.io/cppfront/cpp2/declarations/?h=temp#template-parameters

And here is the example compiled and run on Compiler Explorer:
https://cpp2.godbolt.org/z/azazYWKoa

I'll add class template in another PR.