### PR TITLE
Add the support for some cast functions

### DIFF
--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -865,7 +865,7 @@ repository:
     name: meta.operator.cast.cpp2
     begin: \b(unchecked_narrow|unchecked_cast)\b\s*
     beginCaptures:
-      "1": { name: "keyword.operator.cast.cpp2" }
+      "1": { name: keyword.operator.cast.cpp2 }
     end: (?<=[>])
     patterns:
     - include: '#type-inside-angle-brackets'

--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -37,6 +37,7 @@ repository:
     - include: '#comment'
     - include: '#inspect'
     - include: '#as'
+    - include: '#cast'
     - include: '#is'
     - include: '#unnamed-function'
     - include: '#numeric-range'
@@ -126,7 +127,7 @@ repository:
         "2": { name: punctuation.static-accessor.cpp2 }
       end: (?={{identifier}}[^\w:])
       patterns:
-      - include: '#namespace-access'     
+      - include: '#namespace-access'
 
   variable-name:
     name: meta.entity.variable.cpp2
@@ -860,6 +861,15 @@ repository:
     patterns:
     - include: '#type'
 
+  cast:
+    name: storage.type.cast.cpp2
+    begin: \b(unchecked_narrow|unchecked_cast)\b\s*
+    beginCaptures:
+      "1": { name: storage.type.cast.cpp2 }
+    end: (?<=[>])
+    patterns:
+    - include: '#type-inside-angle-brackets'
+
   function-typing:
     name: meta.typing.cpp2
     begin: (:)(?=[\s*[\(<]])
@@ -1322,21 +1332,33 @@ repository:
           (?x)
           (std)\s*
           (::)\s*
-          (string|vector|map|set|list|queue|stack|priority_queue
-          |pair|tuple
-          |function
-          |thread
-          |mutex|lock_guard|unique_lock
-          |condition_variable
-          |atomic
-          )\b
+          (string|thread|mutex|condition_variable)\b
         captures:
           '1': { name: entity.name.namespace.cpp2 }
           '2': { name: punctuation.static-accessor.cpp2 }
           '3': { name: entity.name.type.cpp2 }
+      - name: meta.entity.known-std-type-name.template.cpp2
+        begin: |
+          (?x)
+          (std)\s*
+          (::)\s*
+          (vector|map|set|list|queue|stack|priority_queue
+          |pair|tuple
+          |function
+          |lock_guard|unique_lock
+          |atomic
+          |dynamic_pointer_cast
+          )\b
+        beginCaptures:
+          '1': { name: entity.name.namespace.cpp2 }
+          '2': { name: punctuation.static-accessor.cpp2 }
+          '3': { name: entity.name.type.cpp2 }
+        end: (?<=[>])
+        patterns:
+        - include: '#type-inside-angle-brackets'
       
   decltype:
-    name: keyword.other.decltype.cpp  
+    name: keyword.other.decltype.cpp
     begin: |
       (?x)
       \b(decltype)\b\s*

--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -862,10 +862,10 @@ repository:
     - include: '#type'
 
   cast:
-    name: storage.type.cast.cpp2
+    name: meta.operator.cast.cpp2
     begin: \b(unchecked_narrow|unchecked_cast)\b\s*
     beginCaptures:
-      "1": { name: storage.type.cast.cpp2 }
+      "1": { name: "keyword.operator.cast.cpp2" }
     end: (?<=[>])
     patterns:
     - include: '#type-inside-angle-brackets'
@@ -1327,6 +1327,34 @@ repository:
           '1': { name: entity.name.namespace.cpp2 }
           '2': { name: punctuation.static-accessor.cpp2 }
           '3': { name: entity.name.variable.cpp2 }
+      - name: meta.entity.known-std-function-name.cpp2
+        match: |
+          (?x)
+          (std)\s*
+          (::)\s*
+          (make_shared|make_unique|make_pair|make_tuple|make_optional|make_any
+          )\b
+          (?=[(])
+        captures:
+          '1': { name: entity.name.namespace.cpp2 }
+          '2': { name: punctuation.static-accessor.cpp2 }
+          '3': { name: entity.name.function.cpp2 }
+      - name: meta.entity.known-std-function-name.template.cpp2
+        begin: |
+          (?x)
+          (std)\s*
+          (::)\s*
+          (make_shared|make_unique|make_pair|make_tuple|make_optional|make_any
+          |dynamic_pointer_cast
+          )\b
+          (?=<)
+        beginCaptures:
+          '1': { name: entity.name.namespace.cpp2 }
+          '2': { name: punctuation.static-accessor.cpp2 }
+          '3': { name: entity.name.function.cpp2 }
+        end: (?<=[>])
+        patterns:
+        - include: '#type-inside-angle-brackets'
       - name: meta.entity.known-std-type-name.cpp2
         match: |
           (?x)
@@ -1347,7 +1375,6 @@ repository:
           |function
           |lock_guard|unique_lock
           |atomic
-          |dynamic_pointer_cast
           )\b
         beginCaptures:
           '1': { name: entity.name.namespace.cpp2 }

--- a/cpp2/syntaxes/cpp2.tmLanguage
+++ b/cpp2/syntaxes/cpp2.tmLanguage
@@ -78,6 +78,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#cast</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#is</string>
           </dict>
           <dict>
@@ -2321,6 +2325,30 @@
           </dict>
         </array>
       </dict>
+      <key>cast</key>
+      <dict>
+        <key>name</key>
+        <string>meta.operator.cast.cpp2</string>
+        <key>begin</key>
+        <string>\b(unchecked_narrow|unchecked_cast)\b\s*</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>storage.type.cast.cpp2</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(?&lt;=[&gt;])</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#type-inside-angle-brackets</string>
+          </dict>
+        </array>
+      </dict>
       <key>function-typing</key>
       <dict>
         <key>name</key>
@@ -3479,14 +3507,7 @@
             <string>(?x)
 (std)\s*
 (::)\s*
-(string|vector|map|set|list|queue|stack|priority_queue
-|pair|tuple
-|function
-|thread
-|mutex|lock_guard|unique_lock
-|condition_variable
-|atomic
-)\b
+(string|thread|mutex|condition_variable)\b
 </string>
             <key>captures</key>
             <dict>
@@ -3506,6 +3527,49 @@
                 <string>entity.name.type.cpp2</string>
               </dict>
             </dict>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>meta.entity.known-std-type-name.template.cpp2</string>
+            <key>begin</key>
+            <string>(?x)
+(std)\s*
+(::)\s*
+(vector|map|set|list|queue|stack|priority_queue
+|pair|tuple
+|function
+|lock_guard|unique_lock
+|atomic
+|dynamic_pointer_cast
+)\b
+</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>entity.name.namespace.cpp2</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.static-accessor.cpp2</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>entity.name.type.cpp2</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?&lt;=[&gt;])</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#type-inside-angle-brackets</string>
+              </dict>
+            </array>
           </dict>
         </array>
       </dict>

--- a/cpp2/syntaxes/cpp2.tmLanguage
+++ b/cpp2/syntaxes/cpp2.tmLanguage
@@ -2336,7 +2336,7 @@
           <key>1</key>
           <dict>
             <key>name</key>
-            <string>storage.type.cast.cpp2</string>
+            <string>keyword.operator.cast.cpp2</string>
           </dict>
         </dict>
         <key>end</key>
@@ -3502,6 +3502,76 @@
           </dict>
           <dict>
             <key>name</key>
+            <string>meta.entity.known-std-function-name.cpp2</string>
+            <key>match</key>
+            <string>(?x)
+(std)\s*
+(::)\s*
+(make_shared|make_unique|make_pair|make_tuple|make_optional|make_any
+)\b
+(?=[(])
+</string>
+            <key>captures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>entity.name.namespace.cpp2</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.static-accessor.cpp2</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>entity.name.function.cpp2</string>
+              </dict>
+            </dict>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>meta.entity.known-std-function-name.template.cpp2</string>
+            <key>begin</key>
+            <string>(?x)
+(std)\s*
+(::)\s*
+(make_shared|make_unique|make_pair|make_tuple|make_optional|make_any
+|dynamic_pointer_cast
+)\b
+(?=&lt;)
+</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>entity.name.namespace.cpp2</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.static-accessor.cpp2</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>entity.name.function.cpp2</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?&lt;=[&gt;])</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#type-inside-angle-brackets</string>
+              </dict>
+            </array>
+          </dict>
+          <dict>
+            <key>name</key>
             <string>meta.entity.known-std-type-name.cpp2</string>
             <key>match</key>
             <string>(?x)
@@ -3540,7 +3610,6 @@
 |function
 |lock_guard|unique_lock
 |atomic
-|dynamic_pointer_cast
 )\b
 </string>
             <key>beginCaptures</key>


### PR DESCRIPTION
3 small changes in this PR:
 - Support cpp2 `unchecked_narrow` and `unchecked_cast`.
 - Support cpp1 `std::dynamic_pointer_cast`.
 - Separates std classes into those that are templates and others for better support.

_Before:_
![image](https://github.com/user-attachments/assets/c33f1e09-c34f-449a-89c0-4246e0e86461)


_After:_
![image](https://github.com/user-attachments/assets/31c02117-a5d9-4524-be40-b3c3fc46902d)

Here is the cppfront documentation about it:
https://hsutter.github.io/cppfront/cpp2/expressions/?h=unchecked_narrow#unchecked-explicitly-type-unsafe-casts

And here is the code compiled and run on Compiler Explorer:
https://cpp2.godbolt.org/z/fY47aY17a

I can't attach a file to the PR so here's the code:
```cpp
A: type = {
    public value: i32 = 4;
    public operator=:(out this) = {}
    public operator=:(out this, that) = {value = that.value;}
}

B: type = {
    public this: A;
    public operator=:(out this) = {A = ();}
    public operator=:(out this, that) = {A = (that);}
}

main: () = {
    b: B = ();
    val: float = unchecked_narrow<float>(b.value);
    assert(val > 0.0f);
    val3:= unchecked_cast<i8>(b.value - 2);
    assert(val3 == 2);
    b_ptr:=  shared.new<B>(b);
    a_ptr:= std::dynamic_pointer_cast<A>(b_ptr);
    a_vec:= std::vector<A>();
    assert(a_vec.empty());
    std::cout << b.value << '\n';
    std::cout << a_ptr*.value << '\n';

}
```
BTW It's the same as the code in the Compiler Explorer link.