### PR TITLE
Add the support for statement-local parameters

### DIFF
--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -528,10 +528,9 @@ repository:
     match: \b({{variable_modifier}})\b
 
   scoped-code-block-with-local-variables-start:
-    begin: (\()(copy)?
+    begin: (\()
     beginCaptures:
       "1": { name: punctuation.parenthesis.open.cpp2 }
-      "2": { name: storage.modifier.cpp2 }
     end: (?<=\))
     endCaptures:
       "1": { name: punctuation.parenthesis.close.cpp2 }
@@ -541,7 +540,7 @@ repository:
 
   scoped-code-block-with-local-variables-start-content:
     patterns:
-    # - include: '#variable-modifier'
+    - include: '#variable-modifier'
     - include: '#variable-inline-definition-typed'
     - include: '#variable-inline-definition-auto'
     - include: '#punctuation-comma'

--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -77,7 +77,7 @@ repository:
     - include: '#comment'
     - include: '#typed-parameter'
     - include: '#punctuation-comma'
-  
+
   parenthesized-expression:
     name: meta.parenthesized-expression.cpp2
     begin: \(
@@ -528,10 +528,11 @@ repository:
     match: \b({{variable_modifier}})\b
 
   scoped-code-block-with-local-variables-start:
-    begin: (\()
+    begin: (\()(copy)?
     beginCaptures:
       "1": { name: punctuation.parenthesis.open.cpp2 }
-    end: (\))
+      "2": { name: storage.modifier.cpp2 }
+    end: (?<=\))
     endCaptures:
       "1": { name: punctuation.parenthesis.close.cpp2 }
     patterns:
@@ -541,7 +542,7 @@ repository:
   scoped-code-block-with-local-variables-start-content:
     patterns:
     # - include: '#variable-modifier'
-    # - include: '#variable-inline-definition-typed'
+    - include: '#variable-inline-definition-typed'
     - include: '#variable-inline-definition-auto'
     - include: '#punctuation-comma'
  
@@ -909,7 +910,7 @@ repository:
       "1": { name: punctuation.separator.colon.cpp2 }
     end: (?=\s*(?=[=;]))
     patterns:
-    - include: '#type'   
+    - include: '#type'
 
   type-name:
     patterns:

--- a/cpp2/syntaxes/cpp2.tmLanguage
+++ b/cpp2/syntaxes/cpp2.tmLanguage
@@ -1457,7 +1457,7 @@
       <key>scoped-code-block-with-local-variables-start</key>
       <dict>
         <key>begin</key>
-        <string>(\()</string>
+        <string>(\()(copy)?</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1465,9 +1465,14 @@
             <key>name</key>
             <string>punctuation.parenthesis.open.cpp2</string>
           </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>storage.modifier.cpp2</string>
+          </dict>
         </dict>
         <key>end</key>
-        <string>(\))</string>
+        <string>(?&lt;=\))</string>
         <key>endCaptures</key>
         <dict>
           <key>1</key>
@@ -1490,6 +1495,10 @@
       <dict>
         <key>patterns</key>
         <array>
+          <dict>
+            <key>include</key>
+            <string>#variable-inline-definition-typed</string>
+          </dict>
           <dict>
             <key>include</key>
             <string>#variable-inline-definition-auto</string>

--- a/cpp2/syntaxes/cpp2.tmLanguage
+++ b/cpp2/syntaxes/cpp2.tmLanguage
@@ -1457,18 +1457,13 @@
       <key>scoped-code-block-with-local-variables-start</key>
       <dict>
         <key>begin</key>
-        <string>(\()(copy)?</string>
+        <string>(\()</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
           <dict>
             <key>name</key>
             <string>punctuation.parenthesis.open.cpp2</string>
-          </dict>
-          <key>2</key>
-          <dict>
-            <key>name</key>
-            <string>storage.modifier.cpp2</string>
           </dict>
         </dict>
         <key>end</key>
@@ -1495,6 +1490,10 @@
       <dict>
         <key>patterns</key>
         <array>
+          <dict>
+            <key>include</key>
+            <string>#variable-modifier</string>
+          </dict>
           <dict>
             <key>include</key>
             <string>#variable-inline-definition-typed</string>


### PR DESCRIPTION
I spent several hours on this change because I couldn't see where or how to do it, but in the end it's a very small change.

I've added support for local variables to the loop, exactly as in the documentation:
https://hsutter.github.io/cppfront/cpp2/functions/#for-while-do-loops
```cpp
main: () = {
    (copy i := 0)
    while i < 10
    next  i++ {
        std::cout << i;
    }
}
```

_Before:_
![image](https://github.com/user-attachments/assets/1b9eb2b5-1fdc-48dd-9140-6cd2b50470a6)
_After:_
![image](https://github.com/user-attachments/assets/b893233a-6412-494d-8e50-b2e1aadabf66)
