### PR TITLE
Add the support for the this keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For any issues, please file them on the [GitHub repo](https://github.com/elazarc
 
 ![Alt text](resources/syntax-highligh-example.png)
 
-## Build
+## Build the extension
 
 ```bash
 yarn install
@@ -27,3 +27,12 @@ yarn run package
 ```
 
 The output VSIX file is located under `cpp2`.
+
+## Compile and run the test file
+
+```bash
+cppfront ./cpp2/test.cpp2 -import-std
+clang++ -I../cppfront/source/ test.cpp -std=c++20 -o test.exe
+./test.exe 
+```
+

--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -8,7 +8,7 @@ variables:
   colon: ':(?:[\s]+|$)'
   coloncolon: '::'
   expression_end: '[;{}()\[\]<=>]|$'
-  parameter_modifier: 'in|out|implicit\s+out|inout|copy|move|forward|virtual'
+  parameter_modifier: 'in|out|inout|copy|move|forward|implicit\s+out|(?:virtual|override|final)\s+(?:in|inout)'
   variable_modifier: 'copy|move|inout'
   return_modifier: 'forward'
   member_modifier: 'public|private|protected'
@@ -177,8 +177,8 @@ repository:
       \b(type)\b\s*
       (==)\s*
     beginCaptures:
-      "1": 
-        patterns: 
+      "1":
+        patterns:
         - include: '#namespace-access'
       "2": { name: entity.name.type.declaration.cpp2 }
       "3": { name: punctuation.separator.colon.cpp2 }
@@ -427,9 +427,12 @@ repository:
       (?={{colon}})
     beginCaptures:
       "1": 
-        patterns: 
+        patterns:
         - include: '#namespace-access'
-      "2": { name: entity.name.variable.declaration.cpp2 }
+      "2":
+        name: entity.name.variable.declaration.cpp2
+        patterns:
+        - include: '#this'
     end: (?<=;)
     patterns:
     - include: '#typing'
@@ -980,6 +983,11 @@ repository:
     captures:
       '1': { name: entity.name.variable.parameter.cpp2 }
 
+  this:
+    match: \bthis\b
+    captures:
+      "0": { name: keyword.this.cpp2 }
+
   untyped-parameter:
     name: meta.untyped-parameter.cpp2
     begin: |
@@ -990,6 +998,7 @@ repository:
       "1":  { name: storage.modifier.cpp2 }
       "2":
         patterns:
+        - include: '#this'
         - include: '#parameter-name'
     end: (?=[\)\,])
 

--- a/cpp2/syntaxes/cpp2.tmLanguage
+++ b/cpp2/syntaxes/cpp2.tmLanguage
@@ -1203,6 +1203,13 @@
           <dict>
             <key>name</key>
             <string>entity.name.variable.declaration.cpp2</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#this</string>
+              </dict>
+            </array>
           </dict>
         </dict>
         <key>end</key>
@@ -2624,13 +2631,26 @@
           </dict>
         </dict>
       </dict>
+      <key>this</key>
+      <dict>
+        <key>match</key>
+        <string>\bthis\b</string>
+        <key>captures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.this.cpp2</string>
+          </dict>
+        </dict>
+      </dict>
       <key>untyped-parameter</key>
       <dict>
         <key>name</key>
         <string>meta.untyped-parameter.cpp2</string>
         <key>begin</key>
         <string>(?x)
-(?:\b(in|out|implicit\s+out|inout|copy|move|forward|virtual)\b\s+)?
+(?:\b(in|out|inout|copy|move|forward|implicit\s+out|(?:virtual|override|final)\s+(?:in|inout))\b\s+)?
 ([_[:alpha:]][_[:alnum:]]*)\s*
 </string>
         <key>beginCaptures</key>
@@ -2644,6 +2664,10 @@
           <dict>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>include</key>
+                <string>#this</string>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>#parameter-name</string>
@@ -2660,7 +2684,7 @@
         <string>meta.typed-parameter.cpp2</string>
         <key>begin</key>
         <string>(?x)
-(?:\b(in|out|implicit\s+out|inout|copy|move|forward|virtual)\b\s+)?
+(?:\b(in|out|inout|copy|move|forward|implicit\s+out|(?:virtual|override|final)\s+(?:in|inout))\b\s+)?
 ([_[:alpha:]][_[:alnum:]]*)\s*
 (:)\s*
 </string>

--- a/cpp2/tests/test.cpp2
+++ b/cpp2/tests/test.cpp2
@@ -1,0 +1,30 @@
+Object: type = {
+    public value: i8;
+
+    public operator=:(implicit out this, v: i8) = {
+        value = v;
+    }
+
+    public id:(virtual inout this) -> i8 = { return 0; }
+    public number_of_legs:(virtual in this) -> i8 = { return 0; }
+}
+
+Chair: type = {
+    this: Object;
+
+    public operator=:(implicit out this, v: i8) = {
+        Object = (v);
+    }
+
+    public id:(override inout this) -> i8 = { return 1; }
+    public number_of_legs:(final in this) -> i8 = { return 4; }
+}
+
+main: () = {
+    (copy i := 0)
+    while i < 10
+    next  i++ {
+        std::cout << i << " ";
+    }
+    std::cout << '\n';
+}


### PR DESCRIPTION
- Add a cpp2 test file.
- Update the README.md to explain who compile and run the cpp2 test file.
- Support the `this` keyword.
- Improve support for the `virtual`, `override` and `final` keywords.
![image](https://github.com/user-attachments/assets/4a343036-586a-4b14-aa13-c63c1ef16263)
