### PR TITLE
Improve "as" keyword

### DIFF
--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -849,16 +849,17 @@ repository:
     beginCaptures:
       "1": { name: keyword.control.is.cpp2 }
     # `=` in inspect, `{` in if.
-    end: (?=[\{=)])
+    end: (?=[\{=)\,])
     patterns:
     - include: '#expression'
+    - include: '#parenthesized-parameters'
 
   as:
     name: meta.operator.as.cpp2
     begin: \b(as)\b\s*
     beginCaptures:
       "1": { name: keyword.control.operator.as.cpp2 }
-    end: (?={{expression_end}})
+    end: (?=[\{=)\,])
     patterns:
     - include: '#type'
 

--- a/cpp2/tests/test.cpp2
+++ b/cpp2/tests/test.cpp2
@@ -17,7 +17,7 @@ Chair: type = {
     }
 
     public id:(override inout this) -> i8 = { return 1; }
-    public number_of_legs:(final in this) -> i8 = { return 4; }
+    public number_of_legs:(final in this) -> i8 = { return std::max(1 as i8, 4 as i8); }
 }
 
 main: () = {


### PR DESCRIPTION
The keyword "as" is now rendered correctly when used with a function parameter.

_Before:_
![image](https://github.com/user-attachments/assets/684146a0-bdb3-4642-8337-01e5a0d9db50)


_After:_
![image](https://github.com/user-attachments/assets/c57f8713-bde8-4c98-a7a2-7869d80e79ee)
