### PR TITLE
Fix "as" keyword

### DIFF
--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -859,7 +859,7 @@ repository:
     begin: \b(as)\b\s*
     beginCaptures:
       "1": { name: keyword.control.operator.as.cpp2 }
-    end: (?=[\{=)\,])
+    end: (?=\s*(?:[\{=)\,+*/\-]|$))
     patterns:
     - include: '#type'
 

--- a/cpp2/tests/test.cpp2
+++ b/cpp2/tests/test.cpp2
@@ -29,6 +29,11 @@ add:(a: i32, b: i32, add_5: bool = false) -> i32 = {
     return result;
 }
 
+print:(a: i8) -> std::string = {
+    text:= a as std::string + "x" + a as std::string;
+    return text;
+}
+
 main: () = {
     count:= add(2, 3, true);
     (copy i := 0)


### PR DESCRIPTION
I first added a test to show the problem.
Then I asked ChatGPT if it could find the problem by showing it the code changes from my last PR and ChatGPT instantly found the problem and proposed a solution.

_Before:_
![image](https://github.com/user-attachments/assets/b8fdcb43-deae-4a92-9b43-81bff2ac7a74)


_After:_
![image](https://github.com/user-attachments/assets/c0b6720b-de94-41ef-95de-783d15b5fbe4)

Sorry again for introducing a bug :persevere: besides not having coded in Cpp2 for a while, I hadn't noticed it.