### PR TITLE
Fix "as" keyword when inside parentheses

### DIFF
--- a/cpp2/src/cpp2.YAML-tmLanguage
+++ b/cpp2/src/cpp2.YAML-tmLanguage
@@ -859,7 +859,7 @@ repository:
     begin: \b(as)\b\s*
     beginCaptures:
       "1": { name: keyword.control.operator.as.cpp2 }
-    end: (?=\s*(?:[\{=)\,+*/\-]|$))
+    end: (?=\s*(?:[+\-*/%&|^<>=,)\]}]|$))
     patterns:
     - include: '#type'
 

--- a/cpp2/tests/test.cpp2
+++ b/cpp2/tests/test.cpp2
@@ -31,6 +31,9 @@ add:(a: i32, b: i32, add_5: bool = false) -> i32 = {
 
 print:(a: i8) -> std::string = {
     text:= a as std::string + "x" + a as std::string;
+    std::cout << "  " << (a + 3) as std::string << " ";
+    text := (a + 1) as std::string + "x" + a as std::string;
+    std::cout << (77 + a) as std::string;
     return text;
 }
 


### PR DESCRIPTION
I found another case where "as" didn't work properly

_Before:_
![image](https://github.com/user-attachments/assets/5bab4406-31ed-4a2e-9d6a-41647bd0c1fd)



_After:_
![image](https://github.com/user-attachments/assets/f1c8e877-e6d5-4ce2-a31b-9f080c085e3e)
